### PR TITLE
fix: Add tools dependencies installation before version generation

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,9 +6,6 @@ on:
       - 'v*'  # Trigger on version tags like v1.0.0
   workflow_dispatch:  # Allow manual trigger
 
-permissions:
-  contents: write
-
 jobs:
   build-macos:
     runs-on: macos-latest
@@ -25,6 +22,10 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: flutter pub get
+      
+      - name: Install tools dependencies
+        working-directory: ./tools
+        run: dart pub get
       
       - name: Generate version info
         run: dart run tools/generate_version.dart

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
-    permissions:
-      contents: write
     
     steps:
       - name: Checkout repository
@@ -24,6 +22,10 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: flutter pub get
+      
+      - name: Install tools dependencies
+        working-directory: ./tools
+        run: dart pub get
       
       - name: Generate version info
         run: dart run tools/generate_version.dart

--- a/.github/workflows/docker-build-web.yml
+++ b/.github/workflows/docker-build-web.yml
@@ -33,6 +33,10 @@ jobs:
         working-directory: ./client
         run: flutter pub get
       
+      - name: Install tools dependencies
+        working-directory: ./tools
+        run: dart pub get
+      
       - name: Generate version info
         run: dart run tools/generate_version.dart
       


### PR DESCRIPTION
- Install dart pub get for tools package in build-windows.yml
- Install dart pub get for tools package in build-macos.yml
- Install dart pub get for tools package in docker-build-web.yml

This fixes the missing 'yaml' package dependency error that was causing version_info.dart generation to fail in GitHub Actions workflows.