### PR TITLE
CI: Also ignore warnings with --no-fatal-warnings

### DIFF
--- a/.github/workflows/branch-checks.yml
+++ b/.github/workflows/branch-checks.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: Run Flutter analyze
         working-directory: ./client
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
       
       - name: Check Dart formatting
         working-directory: ./client

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: ./client
         run: |
           flutter pub get
-          flutter analyze --no-fatal-infos
+          flutter analyze --no-fatal-infos --no-fatal-warnings
           flutter test --no-pub
           dart format --set-exit-if-changed .
         continue-on-error: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
       
       - name: Run Flutter analyze
         working-directory: ./client
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
       
       - name: Check Dart formatting
         working-directory: ./client


### PR DESCRIPTION
- Prevents CI from failing on unused variable/field warnings
- Still fails on actual errors
- Applied to branch-checks, pr-checks, and dependabot workflows